### PR TITLE
Refactor code so as to make it Numba jittable

### DIFF
--- a/miniapp/linalg.py
+++ b/miniapp/linalg.py
@@ -5,7 +5,7 @@
 # Ported to Python by Vasileios Karakasis, CSCS
 
 import collections
-import math
+import numba
 import numpy as np
 import sys
 
@@ -19,6 +19,7 @@ CGStatus = collections.namedtuple('CGStatus',
                                   ['converged', 'iters', 'residual'])
 
 
+@numba.njit(cache=True)
 def cg(x, x_old, b, boundary, options, tolerance, maxiters):
 
     # Initialize temporary storage
@@ -49,10 +50,10 @@ def cg(x, x_old, b, boundary, options, tolerance, maxiters):
     rold = r @ r
     rnew = rold
 
-    if math.sqrt(rold) < tolerance:
-        return CGStatus(True, 0, math.sqrt(rnew))
+    if np.sqrt(rold) < tolerance:
+        return CGStatus(True, 0, np.sqrt(rnew))
 
-    for it in range(maxiters):
+    for it in range(1, maxiters + 1):
         # Ap = A*p
         v = xold + EPS * p
         operators.diffusion(v, Fx, x_old, boundary, options)
@@ -69,7 +70,7 @@ def cg(x, x_old, b, boundary, options, tolerance, maxiters):
         # find new norm
         rnew = r @ r
 
-        residual = math.sqrt(rnew)
+        residual = np.sqrt(rnew)
         if (residual < tolerance):
             return CGStatus(True, it, residual)
 

--- a/miniapp/main.py
+++ b/miniapp/main.py
@@ -8,8 +8,8 @@
 #   Ported to Python by Vasileios Karakasis, CSCS
 
 import collections
-import math
 import matplotlib
+import numba
 import numpy as np
 import os
 import sys
@@ -52,6 +52,7 @@ def parse_arg(v, argname, fn):
     return v
 
 
+@numba.njit(cache=True)
 def timeloop(x, boundary, options, max_cg_iters, max_newton_iters, tolerance):
     # main timeloop
 
@@ -70,7 +71,7 @@ def timeloop(x, boundary, options, max_cg_iters, max_newton_iters, tolerance):
         converged = False
         for it in range(max_newton_iters):
             operators.diffusion(x, b, x_old, boundary, options)
-            residual = math.sqrt(b @ b)
+            residual = np.sqrt(b @ b)
             if residual < tolerance:
                 converged = True
                 break

--- a/miniapp/operators.py
+++ b/miniapp/operators.py
@@ -4,9 +4,11 @@
 # Modified by Ben Cumming, CSCS
 # Ported to Python by Vasileios Karakasis, CSCS
 
+import numba
 import numpy as np
 
 
+@numba.njit(cache=True)
 def diffusion(U, S, x_old, boundary, options):
     dxs = 1000. * options.dx * options.dx
     alpha = options.alpha


### PR DESCRIPTION
Now `timeloop` and `cg` may be successfully jitted with Numba.