### PR TITLE
Matrix-vector demo kernels

### DIFF
--- a/numba-cuda/demo.py
+++ b/numba-cuda/demo.py
@@ -163,8 +163,7 @@ def vecadd(x, y):
 
 
 def validate(found, expected):
-    eps = 1.e-6
-    return all(x < eps for x in np.abs(found - expected))
+    return np.allclose(found, expected)
 
 
 if __name__ == '__main__':
@@ -183,9 +182,22 @@ if __name__ == '__main__':
     version = sys.argv[2]
     try:
         kernel = globals()['gemv_' + version]
-    except NameError:
+    except KeyError:
         print(f'{sys.argv[0]}: ERROR: no such kernel version: {version}',
               file=sys.stderr)
+        versions = []
+        for name in list(globals().keys()):
+            if not name.startswith('gemv_'):
+                continue
+
+            try:
+                version = name.split('_', maxsplit=1)[1]
+            except IndexError:
+                continue
+
+            versions.append(version)
+
+        print(f'  Available versions: {", ".join(versions)}', file=sys.stderr)
         sys.exit(1)
 
     if N <= 0:


### PR DESCRIPTION
Several versions and variants for the matrix-vector kernels:

## Multicore versions

All multicore versions measurements use the C-layout in the input array.

- Numba jitted (parallel, kernel version `v1`): 38.98 GB/s
- Numba jitted (serial, kernel version `v1`): 5.97 GB/s
- Numpy version: 52.97 GB/s

## CUDA versions

- Standard kernel (C-layout): 107.66 GB/s
- Standard kernel (F-layout): 513.42 GB/s (Fortran layout allows coalescing of the memory accesses in the input array)
- Shared memory version (C-layout): 65.53 GB/s
- Shared memory version (F-layout): 389.01 GB/s

Using shared memory in memory bandwidth-bound kernels has no meaning. Used to be more meaningful in early GPU architectures.

Important performance tip: `numba.cuda.jit` does not accept a `cache` argument. If you want to avoid jitting the code when the kernel is called, you have to pass a function signature and the code will be compiled at import time. The JIT overhead is 0.3s of this kernel.